### PR TITLE
Uses array_pop to select value from key and avoid duplicates (closes #3)

### DIFF
--- a/cron.class.php
+++ b/cron.class.php
@@ -16,9 +16,9 @@
 				$connection->post('statuses/update',array('status' => $message));
 		}
 		
-		public function getValueFromKey($array) {
+		public function getValueFromKey(&$array) {
 			$rand_key = array_rand($array, 1);
-			$value = $array[$rand_key];
+			$value = array_pop($rand_key);
 			return $value;
 		}
 	}


### PR DESCRIPTION
Hey @ChelseaStats ,

Following your suggestion, I have set up `getValueFromKey` to use array_pop to select the strings to replace, thus preventing duplicates to be found in the tweets. Please let me know if it's the desired approach 